### PR TITLE
Better Cancel Button Behavior

### DIFF
--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -178,13 +178,14 @@ export default class ActionSheet extends React.Component {
   }
 
   _animateOut(index) {
+    const cancelButtonIndex = this.state.options.cancelButtonIndex;
     if (this.state.isAnimating) {
       return false;
     }
 
-    this.state.onSelect(index);
+    this.state.onSelect(index || cancelButtonIndex);
 
-    if (this.state.options.cancelButtonIndex) {
+    if (cancelButtonIndex) {
       BackAndroid.removeEventListener('actionSheetHardwareBackPress', this._animateOut);
     }
 

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -78,7 +78,7 @@ export default class ActionSheet extends React.Component {
     super(props, context);
 
     this._onSelect   = this._onSelect.bind(this);
-    this._animateOut = this._animateOut.bind(this);
+    this._animateOut = this._animateOut.bind(this, -1);
     this._onLayout   = this._onLayout.bind(this);
 
     this.state = {
@@ -170,14 +170,16 @@ export default class ActionSheet extends React.Component {
     if (this.state.isAnimating) {
       return;
     }
-    this.state.onSelect(index);
+
     this._animateOut();
   }
 
-  _animateOut() {
+  _animateOut(index) {
     if (this.state.isAnimating) {
       return false;
     }
+
+    this.state.onSelect(index);
 
     BackAndroid.removeEventListener('actionSheetHardwareBackPress', this._animateOut);
 

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -106,7 +106,7 @@ export default class ActionSheet extends React.Component {
     let sheet = isVisible ? this._renderSheet() : null;
 
     return (
-      <View style={{flex: 1}}>
+      <View style={[{flex: 1}, this.props.style]}>
         {React.Children.only(this.props.children)}
         {overlay}
         {sheet}

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -78,7 +78,7 @@ export default class ActionSheet extends React.Component {
     super(props, context);
 
     this._onSelect   = this._onSelect.bind(this);
-    this._animateOut = this._animateOut.bind(this, -1);
+    this._animateOut = this._animateOut.bind(this);
     this._onLayout   = this._onLayout.bind(this);
 
     this.state = {

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -170,11 +170,7 @@ export default class ActionSheet extends React.Component {
     if (this.state.isAnimating) {
       return;
     }
-
-    if (index !== this.state.options.cancelButtonIndex) {
-      this.state.onSelect(index);
-    }
-
+    this.state.onSelect(index);
     this._animateOut();
   }
 

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -171,7 +171,7 @@ export default class ActionSheet extends React.Component {
       return;
     }
 
-    this._animateOut();
+    this._animateOut(index);
   }
 
   _animateOut(index) {

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -1,9 +1,5 @@
 'use strict';
-
-import React, {
-  PropTypes,
-} from 'react';
-
+import React, { PropTypes } from 'react';
 import {
   Animated,
   BackAndroid,
@@ -31,7 +27,7 @@ class ActionGroup extends React.Component {
   };
 
   render() {
-    let {
+    const {
       options,
       destructiveButtonIndex,
       onSelect,
@@ -50,8 +46,9 @@ class ActionGroup extends React.Component {
         <TouchableOpacity
           key={i}
           onPress={() => onSelect(i)}
-          style={styles.button}>
-          <Text style={[styles.text, {color}]}>
+          style={styles.button}
+        >
+          <Text style={[styles.text, { color }]}>
             {options[i]}
           </Text>
         </TouchableOpacity>
@@ -77,9 +74,7 @@ export default class ActionSheet extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this._onSelect   = this._onSelect.bind(this);
-    this._animateOut = this._animateOut.bind(this);
-    this._onLayout   = this._onLayout.bind(this);
+    this._onCancel = () => this._onSelect(this.state.options.cancelButtonIndex);
 
     this.state = {
       isVisible: false,
@@ -94,20 +89,20 @@ export default class ActionSheet extends React.Component {
   }
 
   render() {
-    let { isVisible, options } = this.state;
+    const { isVisible, options } = this.state;
 
     let overlay = null;
     if (isVisible) {
       overlay = <Animated.View style={[styles.overlay, { opacity: this.state.overlayOpacity }]} />;
       if (options.cancelButtonIndex) {
-        overlay = <TouchableWithoutFeedback onPress={this._animateOut}>{overlay}</TouchableWithoutFeedback>;
+        overlay = <TouchableWithoutFeedback onPress={this._onCancel}>{overlay}</TouchableWithoutFeedback>;
       }
     }
 
-    let sheet = isVisible ? this._renderSheet() : null;
+    const sheet = isVisible ? this._renderSheet() : null;
 
     return (
-      <View style={[{flex: 1}, this.props.style]}>
+      <View style={[{ flex: 1 }, this.props.style]}>
         {React.Children.only(this.props.children)}
         {overlay}
         {sheet}
@@ -116,12 +111,10 @@ export default class ActionSheet extends React.Component {
   }
 
   _renderSheet() {
-    let numOptions = this.state.options.options.length;
+    const numOptions = this.state.options.options.length;
 
     return (
-      <Animated.View style={[styles.sheetContainer, {
-        bottom: this.state.sheetY,
-      }]}>
+      <Animated.View style={[styles.sheetContainer, { bottom: this.state.sheetY }]}>
         <View onLayout={this._onLayout} style={styles.sheet}>
           <ActionGroup
             options={this.state.options.options}
@@ -165,33 +158,20 @@ export default class ActionSheet extends React.Component {
     }).start();
 
     if (options.cancelButtonIndex) {
-      BackAndroid.addEventListener('actionSheetHardwareBackPress', this._animateOut);
+      this._backAndroidEventListener = BackAndroid.addEventListener('actionSheetHardwareBackPress', this._onCancel);
     }
   }
 
-  _onSelect(index) {
-    if (this.state.isAnimating) {
-      return;
+  _onSelect = index => {
+    if (this.state.isAnimating) return false;
+
+    this.state.onSelect(index);
+
+    if (this._backAndroidEventListener) {
+      this._backAndroidEventListener.remove();
     }
 
-    this._animateOut(index);
-  }
-
-  _animateOut(index) {
-    const cancelButtonIndex = this.state.options.cancelButtonIndex;
-    if (this.state.isAnimating) {
-      return false;
-    }
-
-    this.state.onSelect(index || cancelButtonIndex);
-
-    if (cancelButtonIndex) {
-      BackAndroid.removeEventListener('actionSheetHardwareBackPress', this._animateOut);
-    }
-
-    this.setState({
-      isAnimating: true,
-    });
+    this.setState({ isAnimating: true });
 
     Animated.timing(this.state.overlayOpacity, {
       toValue: 0,
@@ -215,12 +195,12 @@ export default class ActionSheet extends React.Component {
     return true;
   }
 
-  _onLayout(event) {
+  _onLayout = event => {
     if (!this.state.isWaitingForSheetHeight) {
       return;
     }
 
-    let height = event.nativeEvent.layout.height;
+    const height = event.nativeEvent.layout.height;
     this.setState({
       isWaitingForSheetHeight: false,
       sheetHeight: height,
@@ -241,7 +221,7 @@ export default class ActionSheet extends React.Component {
   }
 }
 
-let styles = StyleSheet.create({
+const styles = StyleSheet.create({
   groupContainer: {
     backgroundColor: '#fefefe',
     borderRadius: 4,

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -1,11 +1,14 @@
 'use strict';
 
 import React, {
+  PropTypes,
+} from 'react';
+
+import {
   Animated,
   BackAndroid,
   Easing,
   PixelRatio,
-  PropTypes,
   StyleSheet,
   Text,
   TouchableOpacity,

--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -94,14 +94,15 @@ export default class ActionSheet extends React.Component {
   }
 
   render() {
-    let { isVisible } = this.state;
-    let overlay = isVisible ? (
-      <TouchableWithoutFeedback onPress={this._animateOut}>
-        <Animated.View style={[styles.overlay, {
-          opacity: this.state.overlayOpacity,
-        }]}/>
-      </TouchableWithoutFeedback>
-    ) : null;
+    let { isVisible, options } = this.state;
+
+    let overlay = null;
+    if (isVisible) {
+      overlay = <Animated.View style={[styles.overlay, { opacity: this.state.overlayOpacity }]} />;
+      if (options.cancelButtonIndex) {
+        overlay = <TouchableWithoutFeedback onPress={this._animateOut}>{overlay}</TouchableWithoutFeedback>;
+      }
+    }
 
     let sheet = isVisible ? this._renderSheet() : null;
 
@@ -163,7 +164,9 @@ export default class ActionSheet extends React.Component {
       duration: OPACITY_ANIMATION_TIME,
     }).start();
 
-    BackAndroid.addEventListener('actionSheetHardwareBackPress', this._animateOut);
+    if (options.cancelButtonIndex) {
+      BackAndroid.addEventListener('actionSheetHardwareBackPress', this._animateOut);
+    }
   }
 
   _onSelect(index) {
@@ -181,7 +184,9 @@ export default class ActionSheet extends React.Component {
 
     this.state.onSelect(index);
 
-    BackAndroid.removeEventListener('actionSheetHardwareBackPress', this._animateOut);
+    if (this.state.options.cancelButtonIndex) {
+      BackAndroid.removeEventListener('actionSheetHardwareBackPress', this._animateOut);
+    }
 
     this.setState({
       isAnimating: true,

--- a/ActionSheet.ios.js
+++ b/ActionSheet.ios.js
@@ -9,7 +9,7 @@ import {
 export default class ActionSheet extends React.Component {
   render() {
     return (
-      <View style={{flex: 1}}>
+      <View style={[{flex: 1}, this.props.style]}>
         {React.Children.only(this.props.children)}
       </View>
     );

--- a/ActionSheet.ios.js
+++ b/ActionSheet.ios.js
@@ -1,6 +1,7 @@
 'use strict';
 
-import React, {
+import React from 'react';
+import {
   ActionSheetIOS,
   View,
 } from 'react-native';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exponent/react-native-action-sheet",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A cross-platform ActionSheet for React Native",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
A couple of things this PR is doing:
1) Inherit styles from `this.props.style`. Some people using this component by wrapping their entire app, others (like myself). Stick it besides the app, and use redux to control it. Because it's going beside my app I need to have some custom styling.

2) Create cancel behavior parity between iOS and Android.
Right now when iOS action sheet pops up, if there is a cancel button and you tap the overlay, it will dismiss with the cancel button index as the return value. However if you do not provide the cancel button and you tap the overlay it does nothing. 

Android was just silently hiding when the user pressed the cancel button, and it didn't matter if there was or was not a cancel button provided, if the user tapped the overlay the action sheet would dismiss (silently).

3) Some minor style nits. `let`'s to `const`s, method  bind shorthand, spading & indentation... nothing major but if it goes against your styles let me know and I can make adjustments
