### PR TITLE
Add material design style for Android

### DIFF
--- a/ActionSheet.android.js
+++ b/ActionSheet.android.js
@@ -5,7 +5,6 @@ import {
   Animated,
   BackHandler,
   Easing,
-  PixelRatio,
   Platform,
   StyleSheet,
   Text,
@@ -49,8 +48,10 @@ type ActionSheetProps = {
   useNativeDriver: ?boolean,
 };
 
-const OPACITY_ANIMATION_TIME = 150;
-const PIXEL = 1 / PixelRatio.get();
+const OPACITY_ANIMATION_IN_TIME = 225;
+const OPACITY_ANIMATION_OUT_TIME = 195;
+const EASING_OUT = Easing.bezier(0.25, 0.46, 0.45, 0.94)
+const EASING_IN = Easing.out(EASING_OUT)
 
 class ActionGroup extends React.Component {
   props: ActionGroupProps;
@@ -84,15 +85,19 @@ class ActionGroup extends React.Component {
     );
 
     for (let i = startIndex; i < startIndex + length; i++) {
-      let color = '#444444';
+      let color = '#212121';
       if (i === destructiveButtonIndex) {
-        color = '#ff3b30';
+        color = '#d32f2f';
       }
 
       let iconElement = undefined;
 
       if (icons && icons[i]) {
-        iconElement = <Image source={icons[i]} style={styles.icon} />;
+        const iconStyle = [styles.icon]
+        if (textStyle.color !== undefined && textStyle.color !== null) {
+          iconStyle.push({ tintColor: textStyle.color })
+        }
+        iconElement = <Image source={icons[i]} resizeMode="contain" style={iconStyle} />;
       }
 
       optionViews.push(
@@ -127,6 +132,7 @@ class ActionGroup extends React.Component {
 // Has same API as https://facebook.github.io/react-native/docs/actionsheetios.html
 export default class ActionSheet extends React.Component {
   props: ActionSheetProps;
+  _actionSheetHeight = 360;
   _animateOutCallback: ?() => void = null;
 
   state: ActionSheetState = {
@@ -179,15 +185,16 @@ export default class ActionSheet extends React.Component {
               opacity: this.state.sheetOpacity,
               transform: [
                 {
-                  scale: this.state.sheetOpacity.interpolate({
-                    inputRange: [0, 0.5, 1],
-                    outputRange: [0.6, 1, 1],
+                  translateY: this.state.sheetOpacity.interpolate({
+                    inputRange: [0, 1],
+                    outputRange: [this._actionSheetHeight, 0],
                   }),
                 },
               ],
             },
           ]}>
-          <View style={styles.sheet}>
+          <View style={styles.sheet}
+            onLayout={(event) => { this._actionSheetHeight = event.nativeEvent.layout.height }}>
             <ActionGroup
               options={this.state.options.options}
               icons={this.state.options.icons}
@@ -224,15 +231,15 @@ export default class ActionSheet extends React.Component {
 
     Animated.parallel([
       Animated.timing(this.state.overlayOpacity, {
-        toValue: 0.5,
-        easing: Easing.in(Easing.linear),
-        duration: OPACITY_ANIMATION_TIME,
+        toValue: 0.2,
+        easing: EASING_OUT,
+        duration: OPACITY_ANIMATION_IN_TIME,
         useNativeDriver: this.props.useNativeDriver,
       }),
       Animated.timing(this.state.sheetOpacity, {
         toValue: 1,
-        easing: Easing.in(Easing.linear),
-        duration: OPACITY_ANIMATION_TIME,
+        easing: EASING_OUT,
+        duration: OPACITY_ANIMATION_IN_TIME,
         useNativeDriver: this.props.useNativeDriver,
       }),
     ]).start(result => {
@@ -289,14 +296,14 @@ export default class ActionSheet extends React.Component {
     Animated.parallel([
       Animated.timing(this.state.overlayOpacity, {
         toValue: 0,
-        easing: Easing.in(Easing.linear),
-        duration: OPACITY_ANIMATION_TIME,
+        easing: EASING_IN,
+        duration: OPACITY_ANIMATION_OUT_TIME,
         useNativeDriver: this.props.useNativeDriver,
       }),
       Animated.timing(this.state.sheetOpacity, {
         toValue: 0,
-        easing: Easing.in(Easing.linear),
-        duration: OPACITY_ANIMATION_TIME,
+        easing: EASING_IN,
+        duration: OPACITY_ANIMATION_OUT_TIME,
         useNativeDriver: this.props.useNativeDriver,
       }),
     ]).start(result => {
@@ -359,26 +366,25 @@ class TouchableNativeFeedbackSafe extends React.Component {
 let styles = StyleSheet.create({
   groupContainer: {
     backgroundColor: '#fefefe',
-    borderRadius: 4,
-    borderColor: '#cbcbcb',
-    borderWidth: PIXEL,
+    borderColor: '#ffffff',
+    borderTopWidth: StyleSheet.hairlineWidth,
     overflow: 'hidden',
-    marginHorizontal: 16,
-    marginBottom: 8,
+    paddingVertical: 8,
   },
   button: {
     justifyContent: 'flex-start',
     alignItems: 'center',
     flexDirection: 'row',
-    height: 50,
+    height: 48,
     paddingHorizontal: 16,
   },
   icon: {
-    marginRight: 15,
+    width: 24,
+    height: 24,
+    marginRight: 32,
   },
   text: {
-    fontSize: 17,
-    fontWeight: '700',
+    fontSize: 16,
     textAlignVertical: 'center',
   },
   rowSeparator: {
@@ -401,7 +407,7 @@ let styles = StyleSheet.create({
     bottom: 0,
     top: 0,
     backgroundColor: 'transparent',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     justifyContent: 'center',
     flexDirection: 'row',
   },


### PR DESCRIPTION
Add material design style for Android following material design guidelines

> [Bottom sheets - Components - Material design guidelines](https://material.io/guidelines/components/bottom-sheets.html)

and this is the new look:

![screenshot_1500375313](https://user-images.githubusercontent.com/3497889/28314007-95b0261c-6beb-11e7-8921-61490d92c7a1.png)
