### PR TITLE
Update Documentation to Include Example (updates #37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,60 @@ ActionSheet is a cross-platform React Native component that uses the native UIAc
 npm install @expo/react-native-action-sheet
 ```
 
+## A basic ActionSheet Setup
+
+import ActionSheetProvider & connectActionSheet
+
+```
+import { ActionSheetProvider, connectActionSheet } from '@expo/react-native-action-sheet';
+```
+
+wrap your top-level component with `<ActionSheetProvider />`
+
+```
+class AppContainer extends React.Component {
+  render() {
+    return (
+      <ActionSheetProvider>
+        <App />
+      </ActionSheetProvider>
+    );
+  }
+}
+```
+
+decorate the component you want to use the action sheet with `@connectActionSheet`
+
+```
+@connectActionSheet
+class App extends React.Component { /* ... */ }
+```
+
+access actionSheet method as `this.props.showActionSheetWithOptions`
+
+```
+_onOpenActionSheet = () => {
+  // Same interface as https://facebook.github.io/react-native/docs/actionsheetios.html
+  let options = ['Delete', 'Save', 'Cancel'];
+  let destructiveButtonIndex = 0;
+  let cancelButtonIndex = 2;
+  
+  this.props.showActionSheetWithOptions({
+    options,
+    cancelButtonIndex,
+    destructiveButtonIndex,
+  },
+  (buttonIndex) => {
+    // Do something here depending on the button index selected
+  });
+
+}
+```
+
+
 ## Try it out
 
-Try it with Expo: https://expo.io/@community/react-native-action-sheet-example
+Try it in Expo: https://expo.io/@community/react-native-action-sheet-example
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ npm install @expo/react-native-action-sheet
 
 import ActionSheetProvider & connectActionSheet
 
-```
+```es6
 import { ActionSheetProvider, connectActionSheet } from '@expo/react-native-action-sheet';
 ```
 
 wrap your top-level component with `<ActionSheetProvider />`
 
-```
+```es6
 class AppContainer extends React.Component {
   render() {
     return (
@@ -31,14 +31,14 @@ class AppContainer extends React.Component {
 
 decorate the component you want to use the action sheet with `@connectActionSheet`
 
-```
+```es6
 @connectActionSheet
 class App extends React.Component { /* ... */ }
 ```
 
 access actionSheet method as `this.props.showActionSheetWithOptions`
 
-```
+```es6
 _onOpenActionSheet = () => {
   // Same interface as https://facebook.github.io/react-native/docs/actionsheetios.html
   let options = ['Delete', 'Save', 'Cancel'];


### PR DESCRIPTION
@dabit3 (thanks!) updated the README to include an example. This is the same thing except updated:

- getexpo.com -> expo.io
- renamed Exponent to Expo