### PR TITLE
Allows Android textStyle to be declared at the Provider

### DIFF
--- a/ActionSheetProvider.js
+++ b/ActionSheetProvider.js
@@ -4,6 +4,7 @@ import ActionSheet from './ActionSheet';
 
 export default class ActionSheetProvider extends React.Component {
   static propTypes = {
+    textStyle: PropTypes.Object,
     children: PropTypes.any,
   };
 
@@ -11,10 +12,19 @@ export default class ActionSheetProvider extends React.Component {
     showActionSheetWithOptions: PropTypes.func,
   };
 
+  static defaultProps = {
+    textStyle: {}
+  }
+
   getChildContext() {
     return {
-      showActionSheetWithOptions: (...args) =>
-        this._actionSheetRef.showActionSheetWithOptions(...args),
+      showActionSheetWithOptions: (...args) => {
+        const [config, ...rest] = args
+        const textStyle = {...this.props.textStyle, ...config.textStyle}
+        const nextConfig = {...config, textStyle}
+
+        this._actionSheetRef.showActionSheetWithOptions(nextConfig, ...rest)
+      },
     };
   }
 


### PR DESCRIPTION
Intead of having to pass `textStyles` to every call of ActionSheet, this PR allows to specify `textStyles` once and be reused across all instances. Afterall, it will be most-common case to share the look and feel throughout the application.

You can test it like the following:

```
      <Provider store={store}>
        <ActionSheetProvider textStyle={{fontWeight: '400'}}>
          <AppBase />
        </ActionSheetProvider>
      </Provider>
```

It should be backwards compatible. Also, this pattern would be extensible for other options that could be shared across action sheets.

Edits, considerations, corrections, are more than welcome.