### PR TITLE
Fixes an IOS issue for when not passing tintColor. 

### DIFF
--- a/ActionSheetProvider.js
+++ b/ActionSheetProvider.js
@@ -21,7 +21,7 @@ export default class ActionSheetProvider extends React.Component {
   static defaultProps = {
     textStyle: {},
     tintIcons: true,
-    tintColor: null,
+    tintColor: undefined,
     titleTextStyle: {},
     messageTextStyle: {},
     showSeparators: false,


### PR DESCRIPTION
Fixes 
```JSON value '<null>' of type NSNull cannot be converted to a UIColor. Did you forget to call processColor() on the JS side?```
See [#78](https://github.com/expo/react-native-action-sheet/pull/78#issuecomment-446657849)