### PR TITLE
Make action sheet non cancelable if button index is not supplied

### DIFF
--- a/ActionSheet.js
+++ b/ActionSheet.js
@@ -353,7 +353,9 @@ export default class ActionSheet extends React.Component {
       return false;
     }
 
-    if (typeof options.cancelButtonIndex === 'number') {
+    if (typeof options.cancelButtonIndex === 'undefined') {
+      return;
+    } else if (typeof options.cancelButtonIndex === 'number') {
       return this._onSelect(options.cancelButtonIndex);
     } else {
       return this._animateOut();


### PR DESCRIPTION
This mimics the behaviour of React Native's ActionSheetIOS. When cancelButtonIndex is not supplied in the options object the action sheet is non cancelable. You can not click on the outside overlay to remove the action sheet. This addition also disables canceling the action sheet by pressing the back button on Android.

Small change but was needed for the project that I was working on.
