### PR TITLE
Allow pointer events to pass through containing view

### DIFF
--- a/src/ActionSheet/index.ios.tsx
+++ b/src/ActionSheet/index.ios.tsx
@@ -1,16 +1,21 @@
 import * as React from 'react';
-import { ActionSheetIOS, View } from 'react-native';
+import { ActionSheetIOS, View, ViewProps } from 'react-native';
 import { ActionSheetIOSOptions } from '../types';
 
 interface Props {
   readonly children: React.ReactNode;
+  readonly pointerEvents?: ViewProps['pointerEvents'];
 }
 
 type onSelect = (buttonIndex: number) => void;
 
 export default class ActionSheet extends React.Component<Props> {
   render() {
-    return <View style={{ flex: 1 }}>{React.Children.only(this.props.children)}</View>;
+    return (
+      <View pointerEvents={this.props.pointerEvents} style={{ flex: 1 }}>
+        {React.Children.only(this.props.children)}
+      </View>
+    );
   }
 
   showActionSheetWithOptions(options: ActionSheetIOSOptions, onSelect: onSelect) {

--- a/src/ActionSheet/index.tsx
+++ b/src/ActionSheet/index.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   TouchableWithoutFeedback,
   View,
+  ViewProps,
 } from 'react-native';
 import ActionGroup from './ActionGroup';
 import { ActionSheetOptions } from '../types';
@@ -21,6 +22,7 @@ interface State {
 
 interface Props {
   readonly useNativeDriver: boolean | undefined;
+  readonly pointerEvents?: ViewProps['pointerEvents'];
 }
 
 const OPACITY_ANIMATION_IN_TIME = 225;
@@ -64,6 +66,7 @@ export default class ActionSheet extends React.Component<Props, State> {
     ) : null;
     return (
       <View
+        pointerEvents={this.props.pointerEvents}
         style={{
           flex: 1,
         }}>


### PR DESCRIPTION
I'm using this library with react-native-navigation, and when we use an [overlay](https://wix.github.io/react-native-navigation/#/docs/top-level-api?id=showoverlaylayout-) to show in an app notification, the ActionSheetProvider blocks any touches to the screen below, even when we set the `interceptTouchOutside` option of the overlay to false. This PR fixes this and allows touches to pass through to below.