### PR TITLE
Android: fix duplicate separator key when key arg == 0

### DIFF
--- a/src/ActionSheet/ActionGroup.tsx
+++ b/src/ActionSheet/ActionGroup.tsx
@@ -34,10 +34,7 @@ export default class ActionGroup extends React.Component<Props> {
 
   _renderRowSeparator = (key: string | number) => {
     return (
-      <View
-        key={key && `separator-${key}`}
-        style={[styles.rowSeparator, this.props.separatorStyle]}
-      />
+      <View key={`separator-${key}`} style={[styles.rowSeparator, this.props.separatorStyle]} />
     );
   };
 


### PR DESCRIPTION
On Android with `showSeparators` enabled when rendering the first separator after the option, the generated key was "0" (and not "separator-0"), which is the same key as the optionn row key, so React complained about a duplicate key.