### PR TITLE
Export ActionSheetContext

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -4,11 +4,11 @@ import {
   ActionSheetProvider,
   connectActionSheet,
   ActionSheetOptions,
-  ActionSheetContext,
+  ActionSheetProps,
 } from '@expo/react-native-action-sheet';
 import ShowActionSheetButton from './ShowActionSheetButton';
 
-type Props = ActionSheetContext;
+type Props = ActionSheetProps;
 
 interface State {
   selectedIndex: number | null;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -4,12 +4,11 @@ import {
   ActionSheetProvider,
   connectActionSheet,
   ActionSheetOptions,
+  ActionSheetContext,
 } from '@expo/react-native-action-sheet';
 import ShowActionSheetButton from './ShowActionSheetButton';
 
-interface Props {
-  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => void;
-}
+type Props = ActionSheetContext;
 
 interface State {
   selectedIndex: number | null;

--- a/src/connectActionSheet.tsx
+++ b/src/connectActionSheet.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Consumer, Context } from './context';
+import { Consumer } from './context';
 import hoistNonReactStatic from 'hoist-non-react-statics';
+import { ActionSheetProps } from './types';
 
 export default function connectActionSheet<OwnProps = any>(
-  WrappedComponent: React.ComponentType<OwnProps & Context>
+  WrappedComponent: React.ComponentType<OwnProps & ActionSheetProps>
 ) {
   const ConnectedActionSheet = (props: OwnProps) => {
     return (

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,11 +1,7 @@
 import * as React from 'react';
-import { ActionSheetOptions } from './types';
+import { ActionSheetOptions, ActionSheetContext } from './types';
 
-export interface Context {
-  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => void;
-}
-
-const context = React.createContext<Context>({
+const context = React.createContext<ActionSheetContext>({
   showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => {},
 });
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { ActionSheetOptions, ActionSheetContext } from './types';
+import { ActionSheetOptions, ActionSheetProps } from './types';
 
-const context = React.createContext<ActionSheetContext>({
+const context = React.createContext<ActionSheetProps>({
   showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => {},
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { default as ActionSheetProvider } from './ActionSheetProvider';
 export { default as connectActionSheet } from './connectActionSheet';
-export { useActionSheet, Context as ActionSheetContext } from './context';
+export { useActionSheet } from './context';
 export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { default as ActionSheetProvider } from './ActionSheetProvider';
 export { default as connectActionSheet } from './connectActionSheet';
-export { useActionSheet } from './context';
+export { useActionSheet, Context as ActionSheetContext } from './context';
 export * from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { TextStyle, ViewStyle } from 'react-native';
 
+export interface ActionSheetContext {
+  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => void;
+}
+
 // for iOS
 export interface ActionSheetIOSOptions {
   options: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { TextStyle, ViewStyle } from 'react-native';
 
-export interface ActionSheetContext {
+export interface ActionSheetProps {
   showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => void;
 }
 


### PR DESCRIPTION
When using connectActionSheet, component props shoud have Context.
So need to type `showActionSheetWithOptions: (options:
ActionSheetOptions, callback: (i: number) => void) => void;` many times.

Context is exported, but it is too common name and cant import from
`'@expo/react-native-action-sheet'`.