### PR TITLE
Add anchor option for iPads

### DIFF
--- a/src/ActionSheet/index.ios.tsx
+++ b/src/ActionSheet/index.ios.tsx
@@ -31,6 +31,7 @@ export default class ActionSheet extends React.Component<Props> {
       // A null title or message on iOS causes a crash
       title: dataOptions.title || undefined,
       message: dataOptions.message || undefined,
+      anchor: dataOptions.anchor || undefined,
     };
     ActionSheetIOS.showActionSheetWithOptions(iosOptions, onSelect);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,7 @@ export interface ActionSheetIOSOptions {
   tintColor?: string;
   cancelButtonIndex?: number;
   destructiveButtonIndex?: number;
+  anchor?: number;
 }
 
 // for Android or Web


### PR DESCRIPTION
https://facebook.github.io/react-native/docs/actionsheetios#showactionsheetwithoptions

You can view the usage on this question (and answer) of mine 
https://stackoverflow.com/questions/57356674/how-to-use-the-anchor-option-for-ipad-in-react-natives-actionsheetios

This is what this option does. It's not working at the moment in this library.
![Screenshot 2020-01-13 at 4 26 38 PM](https://user-images.githubusercontent.com/13067699/72250456-a186ad00-3621-11ea-8985-d243fd94b124.png)
