### PR TITLE
chore: ipad anchor in example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ This library can also be used in the browser with Expo for web.
 
 The same options available on React Native's [ActionSheetIOS](https://facebook.github.io/react-native/docs/actionsheetios.html#showactionsheetwithoptions) component exist for both iOS and Android in this library.
 
+### iOS Only Props
+
+| Name             | Type   | Required | Default |
+| -----------------| -------| -------- | ------- |
+| anchor           | number | No       |         |
+
+#### `anchor` (optional) 
+iPad only option that allows for docking the action sheet to a node. See [ShowActionSheetButton.tsx](/example/ShowActionSheetButton.tsx) for an example on how to implement this.
+
 ### Android/Web-Only Props
 
 The below props allow modification of the Android ActionSheet. They have no effect on the look on iOS as the native iOS Action Sheet does not have options for modifying these options.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -63,6 +63,13 @@ class App extends React.Component<Props, State> {
           showActionSheetWithOptions={showActionSheetWithOptions}
         />
         <ShowActionSheetButton
+          title="iPad Anchor"
+          withAnchor
+          withTitle
+          onSelection={this._updateSelectionText}
+          showActionSheetWithOptions={showActionSheetWithOptions}
+        />
+        <ShowActionSheetButton
           title="Nested Action Sheets"
           onSelection={index => {
             if (index < 3) {

--- a/example/ShowActionSheetButton.tsx
+++ b/example/ShowActionSheetButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text, View, TextStyle, ViewStyle } from 'react-native';
+import { Text, View, TextStyle, ViewStyle, findNodeHandle, Button } from 'react-native';
 import { MaterialIcons, Entypo } from '@expo/vector-icons';
 import { ActionSheetOptions } from '@expo/react-native-action-sheet';
 
@@ -17,6 +17,7 @@ interface Props {
   withIcons?: boolean;
   withSeparators?: boolean;
   withCustomStyles?: boolean;
+  withAnchor?: boolean;
 }
 
 // A custom button that shows examples of different share sheet configurations
@@ -27,11 +28,15 @@ export default class ShowActionSheetButton extends React.PureComponent<Props> {
     withIcons: false,
     withSeparators: false,
     withCustomStyles: false,
+    withAnchor: false,
     onSelection: null,
   };
 
+  _anchorRef = React.createRef<Button>();
+
   _showActionSheet = () => {
     const {
+      withAnchor,
       withTitle,
       withMessage,
       withIcons,
@@ -79,6 +84,9 @@ export default class ShowActionSheetButton extends React.PureComponent<Props> {
           backgroundColor: 'lightgrey',
         }
       : undefined;
+    const anchor: number | null = this._anchorRef.current
+      ? findNodeHandle(this._anchorRef.current)
+      : null;
 
     showActionSheetWithOptions(
       {
@@ -88,6 +96,8 @@ export default class ShowActionSheetButton extends React.PureComponent<Props> {
         title,
         message,
         icons,
+        //iPad only
+        anchor: withAnchor && anchor ? anchor : undefined,
         // Android only
         tintIcons: true,
         // Android only; default is true
@@ -101,7 +111,7 @@ export default class ShowActionSheetButton extends React.PureComponent<Props> {
         // Android only,
         containerStyle,
       },
-      buttonIndex => {
+      (buttonIndex: number) => {
         // Do something here depending on the button index selected
         onSelection(buttonIndex);
       }
@@ -115,7 +125,11 @@ export default class ShowActionSheetButton extends React.PureComponent<Props> {
         style={{
           margin: 6,
         }}>
-        <Entypo.Button name="code" backgroundColor="#3e3e3e" onPress={this._showActionSheet}>
+        <Entypo.Button
+          name="code"
+          backgroundColor="#3e3e3e"
+          onPress={this._showActionSheet}
+          ref={this._anchorRef}>
           <Text
             style={{
               fontSize: 15,


### PR DESCRIPTION
This adds a `withAnchor` option to `ShowActionSheetButton` to demo how the anchor works. Also updated the readme.