### PR TITLE
Improvements to Android accessibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The below props allow modification of the Android ActionSheet. They have no effe
 | textStyle        | TextStyle                         | No       |         |
 | titleTextStyle   | TextStyle                         | No       |         |
 | messageTextStyle | TextStyle                         | No       |         |
+| autoFocus        | boolean                           | No       |  false  |
 | showSeparators   | boolean                           | No       |  false  |
 | containerStyle   | ViewStyle                         | No       |         |
 | separatorStyle   | ViewStyle                         | No       |         |
@@ -136,6 +137,10 @@ Apply any text style props to the title if present.
 
 #### `messageTextStyle` (optional)
 Apply any text style props to the message if present.
+
+#### `autoFocus`: (optional)
+If true, will give the first option screen reader focus automatically when the action sheet becomes visible.
+On iOS, this is the default behavior of the native action sheet.
 
 #### `showSeparators`: (optional)
 Show separators between items. On iOS, separators always show so this prop has no effect.

--- a/src/ActionSheet/ActionGroup.tsx
+++ b/src/ActionSheet/ActionGroup.tsx
@@ -112,6 +112,7 @@ export default class ActionGroup extends React.Component<Props> {
       length,
       textStyle,
       tintColor,
+      autoFocus,
       showSeparators,
     } = this.props;
     const optionViews: React.ReactNode[] = [];
@@ -129,7 +130,7 @@ export default class ActionGroup extends React.Component<Props> {
 
       optionViews.push(
         <TouchableNativeFeedbackSafe
-          ref={i === 0 ? focusViewOnRender : undefined}
+          ref={autoFocus && i === 0 ? focusViewOnRender : undefined}
           key={i}
           pressInDelay={0}
           background={nativeFeedbackBackground}

--- a/src/ActionSheet/ActionGroup.tsx
+++ b/src/ActionSheet/ActionGroup.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
-import { StyleSheet, Text, Image, View, ScrollView } from 'react-native';
+import {
+  StyleSheet,
+  Text,
+  Image,
+  View,
+  ScrollView,
+  findNodeHandle,
+  AccessibilityInfo,
+  Platform,
+  UIManager,
+} from 'react-native';
 import TouchableNativeFeedbackSafe from './TouchableNativeFeedbackSafe';
 import { ActionSheetOptions } from '../types';
 
@@ -13,6 +23,28 @@ type Props = ActionSheetOptions & {
 const BLACK_54PC_TRANSPARENT = '#0000008a';
 const BLACK_87PC_TRANSPARENT = '#000000de';
 const DESTRUCTIVE_COLOR = '#d32f2f';
+
+/**
+ * Can be used as a React ref for a component to auto-focus for accessibility on render.
+ * @param ref The component to auto-focus
+ */
+const focusViewOnRender = (ref: React.Component | null) => {
+  if (ref) {
+    const reactTag = findNodeHandle(ref);
+    if (reactTag) {
+      if (Platform.OS === 'android') {
+        // @ts-ignore: sendAccessibilityEvent is missing from @types/react-native
+        UIManager.sendAccessibilityEvent(
+          reactTag,
+          // @ts-ignore: AccessibilityEventTypes is missing from @types/react-native
+          UIManager.AccessibilityEventTypes.typeViewFocused
+        );
+      } else {
+        AccessibilityInfo.setAccessibilityFocus(reactTag);
+      }
+    }
+  }
+};
 
 export default class ActionGroup extends React.Component<Props> {
   static defaultProps = {
@@ -97,11 +129,13 @@ export default class ActionGroup extends React.Component<Props> {
 
       optionViews.push(
         <TouchableNativeFeedbackSafe
+          ref={i === 0 ? focusViewOnRender : undefined}
           key={i}
           pressInDelay={0}
           background={nativeFeedbackBackground}
           onPress={() => onSelect(i)}
           style={styles.button}
+          accessibilityRole="button"
           accessibilityLabel={options[i]}>
           {this._renderIconElement(iconSource, color)}
           <Text style={[styles.text, textStyle, { color }]}>{options[i]}</Text>

--- a/src/ActionSheet/index.tsx
+++ b/src/ActionSheet/index.tsx
@@ -7,6 +7,7 @@ import {
   TouchableWithoutFeedback,
   View,
   ViewProps,
+  ViewStyle,
 } from 'react-native';
 import ActionGroup from './ActionGroup';
 import { ActionSheetOptions } from '../types';
@@ -25,6 +26,7 @@ interface Props {
   readonly pointerEvents?: ViewProps['pointerEvents'];
 }
 
+const FLEX_ONE_STYLE: ViewStyle = { flex: 1 };
 const OPACITY_ANIMATION_IN_TIME = 225;
 const OPACITY_ANIMATION_OUT_TIME = 195;
 const EASING_OUT = Easing.bezier(0.25, 0.46, 0.45, 0.94);
@@ -64,13 +66,19 @@ export default class ActionSheet extends React.Component<Props, State> {
         ]}
       />
     ) : null;
-    return (
+
+    // While the sheet is visible, hide the rest of the app's content from screen readers.
+    const appContent = (
       <View
-        pointerEvents={this.props.pointerEvents}
-        style={{
-          flex: 1,
-        }}>
+        style={FLEX_ONE_STYLE}
+        importantForAccessibility={isVisible ? 'no-hide-descendants' : 'auto'}>
         {React.Children.only(this.props.children)}
+      </View>
+    );
+
+    return (
+      <View pointerEvents={this.props.pointerEvents} style={FLEX_ONE_STYLE}>
+        {appContent}
         {overlay}
         {isVisible ? this._renderSheet() : null}
       </View>
@@ -100,7 +108,7 @@ export default class ActionSheet extends React.Component<Props, State> {
       separatorStyle,
     } = options;
     return (
-      <TouchableWithoutFeedback onPress={this._selectCancelButton}>
+      <TouchableWithoutFeedback importantForAccessibility="yes" onPress={this._selectCancelButton}>
         <Animated.View
           needsOffscreenAlphaCompositing={isAnimating}
           style={[

--- a/src/ActionSheet/index.tsx
+++ b/src/ActionSheet/index.tsx
@@ -113,6 +113,7 @@ export default class ActionSheet extends React.Component<Props, State> {
       titleTextStyle,
       message,
       messageTextStyle,
+      autoFocus,
       showSeparators,
       containerStyle,
       separatorStyle,
@@ -150,6 +151,7 @@ export default class ActionSheet extends React.Component<Props, State> {
               titleTextStyle={titleTextStyle}
               message={message || undefined}
               messageTextStyle={messageTextStyle}
+              autoFocus={autoFocus}
               showSeparators={showSeparators}
               containerStyle={containerStyle}
               separatorStyle={separatorStyle}

--- a/src/ActionSheet/index.tsx
+++ b/src/ActionSheet/index.tsx
@@ -26,7 +26,6 @@ interface Props {
   readonly pointerEvents?: ViewProps['pointerEvents'];
 }
 
-const FLEX_ONE_STYLE: ViewStyle = { flex: 1 };
 const OPACITY_ANIMATION_IN_TIME = 225;
 const OPACITY_ANIMATION_OUT_TIME = 195;
 const EASING_OUT = Easing.bezier(0.25, 0.46, 0.45, 0.94);
@@ -70,14 +69,14 @@ export default class ActionSheet extends React.Component<Props, State> {
     // While the sheet is visible, hide the rest of the app's content from screen readers.
     const appContent = (
       <View
-        style={FLEX_ONE_STYLE}
+        style={styles.flexContainer}
         importantForAccessibility={isVisible ? 'no-hide-descendants' : 'auto'}>
         {React.Children.only(this.props.children)}
       </View>
     );
 
     return (
-      <View pointerEvents={this.props.pointerEvents} style={FLEX_ONE_STYLE}>
+      <View pointerEvents={this.props.pointerEvents} style={styles.flexContainer}>
         {appContent}
         {overlay}
         {isVisible ? this._renderSheet() : null}
@@ -260,6 +259,9 @@ export default class ActionSheet extends React.Component<Props, State> {
 }
 
 const styles = StyleSheet.create({
+  flexContainer: {
+    flex: 1,
+  },
   overlay: {
     position: 'absolute',
     top: 0,

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface ActionSheetOptions extends ActionSheetIOSOptions {
   textStyle?: TextStyle;
   titleTextStyle?: TextStyle;
   messageTextStyle?: TextStyle;
+  autoFocus?: boolean;
   showSeparators?: boolean;
   containerStyle?: ViewStyle;
   separatorStyle?: ViewStyle;


### PR DESCRIPTION
Hi there - love this library but have run into some trouble with Android screen reader support:

- Action sheet items don't have a role assigned; "button" is a good fit I think - iOS reads them as buttons
- The rest of the app is still accessible behind the action sheet :(

I didn't see existing issues for these (especially the second one), and can open if desired!

This changes adds the Android-focused prop `importantForAccessibility="yes"` to the sheet while it's being rendered, as well as `"no-hide-descendants"` to the wrapped app content while the sheet is open. This ensures that only the action sheet content is accessible until it gets closed. This requires the app content to be wrapped in a new `<View>`, because there's no guarantee that the user is passing in something that takes accessibility props), but this seems to work out fine with `flex: 1` (and react-native-action-sheet is adding its own wrapper <View> already anyway).

I also added the "button" role to the action sheet options, and added a ref callback that will cause the screen reader to focus the first option/button in the list when the sheet opens (iOS has this behavior).

I tested this in my application and am happy with the results - our use case is rendering a React fragment inside of the ActionSheetProvider, I also tested it with a View being rendered as the child instead. 

Also tested running the repo's example app on both my Android device (worked for all the examples) and the web variant. Verified that Narrator, using Edge on Windows, is reading the options as buttons now and no longer focuses the example app content while the sheet is open.

Happy to do additional testing if there scenarios that need to be covered.

### New Android screen reader behavior (tested on a Galaxy S8, Android 9)
- First option in the action sheet takes TalkBack focus when sheet pops up
- Each option is read as a button by TalkBack
- User can swipe left to focus the sheet itself and double tap to close/cancel or swipe right to enumerate the rest of the options; TalkBack cycles between the sheet and the last option and the rest of the app is not accessible until the sheet is closed

RN Documentation References:

* [importantForAccessibility Android prop](https://reactnative.dev/docs/accessibility.html#importantforaccessibility-android)
* [accessibilityRole prop](https://reactnative.dev/docs/accessibility.html#accessibilityrole-ios-android)
* [Focusing a view on Android](https://reactnative.dev/docs/accessibility.html#sending-accessibility-events-android) (works well but the relevant APIs seem to be missing from @types/react-native)
