### PR TITLE
feat: add `userInterfaceStyle` option for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ The same options available on React Native's [ActionSheetIOS](https://facebook.g
 #### `anchor` (optional)
 iPad only option that allows for docking the action sheet to a node. See [ShowActionSheetButton.tsx](/example/ShowActionSheetButton.tsx) for an example on how to implement this.
 
+| Name               | Type   | Required | Default |
+| -------------------| -------| -------- | ------- |
+| userInterfaceStyle | string | No       |         |
+
+#### `userInterfaceStyle` (optional)
+The interface style used for the action sheet, can be set to `light` or `dark`, otherwise the default system style will be used.
+
 ### Android/Web-Only Props
 
 The below props allow modification of the Android ActionSheet. They have no effect on the look on iOS as the native iOS Action Sheet does not have options for modifying these options.

--- a/README.md
+++ b/README.md
@@ -98,16 +98,13 @@ The same options available on React Native's [ActionSheetIOS](https://facebook.g
 
 ### iOS Only Props
 
-| Name             | Type   | Required | Default |
-| -----------------| -------| -------- | ------- |
-| anchor           | number | No       |         |
+| Name               | Type   | Required | Default |
+| -------------------| -------| -------- | ------- |
+| anchor             | number | No       |         |
+| userInterfaceStyle | string | No       |         |
 
 #### `anchor` (optional)
 iPad only option that allows for docking the action sheet to a node. See [ShowActionSheetButton.tsx](/example/ShowActionSheetButton.tsx) for an example on how to implement this.
-
-| Name               | Type   | Required | Default |
-| -------------------| -------| -------- | ------- |
-| userInterfaceStyle | string | No       |         |
 
 #### `userInterfaceStyle` (optional)
 The interface style used for the action sheet, can be set to `light` or `dark`, otherwise the default system style will be used.

--- a/src/ActionSheet/index.ios.tsx
+++ b/src/ActionSheet/index.ios.tsx
@@ -32,6 +32,7 @@ export default class ActionSheet extends React.Component<Props> {
       title: dataOptions.title || undefined,
       message: dataOptions.message || undefined,
       anchor: dataOptions.anchor || undefined,
+      userInterfaceStyle: dataOptions.userInterfaceStyle || undefined,
     };
     ActionSheetIOS.showActionSheetWithOptions(iosOptions, onSelect);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,7 +14,7 @@ export interface ActionSheetIOSOptions {
   cancelButtonIndex?: number;
   destructiveButtonIndex?: number;
   anchor?: number;
-  userInterfaceStyle?: string;
+  userInterfaceStyle?: 'light' | 'dark';
 }
 
 // for Android or Web

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface ActionSheetIOSOptions {
   cancelButtonIndex?: number;
   destructiveButtonIndex?: number;
   anchor?: number;
+  userInterfaceStyle?: string;
 }
 
 // for Android or Web


### PR DESCRIPTION
This PR adds the `userInterfaceStyle` option for iOS.
It can be set to `light` or `dark`, otherwise the default system style will be used.

See https://reactnative.dev/docs/actionsheetios#showactionsheetwithoptions

fix #197