### PR TITLE
Allow multiple destructive indices

### DIFF
--- a/src/ActionSheet/ActionGroup.tsx
+++ b/src/ActionSheet/ActionGroup.tsx
@@ -1,14 +1,14 @@
 import * as React from 'react';
 import {
+  AccessibilityInfo,
+  findNodeHandle,
+  Image,
+  Platform,
+  ScrollView,
   StyleSheet,
   Text,
-  Image,
-  View,
-  ScrollView,
-  findNodeHandle,
-  AccessibilityInfo,
-  Platform,
   UIManager,
+  View,
 } from 'react-native';
 import TouchableNativeFeedbackSafe from './TouchableNativeFeedbackSafe';
 import { ActionSheetOptions } from '../types';
@@ -44,6 +44,14 @@ const focusViewOnRender = (ref: React.Component | null) => {
       }
     }
   }
+};
+
+const isIndexDestructive = (index: number, destructiveIndex?: number | number[]) => {
+  if (Array.isArray(destructiveIndex)) {
+    return destructiveIndex.includes(index);
+  }
+
+  return index === destructiveIndex;
 };
 
 export default class ActionGroup extends React.Component<Props> {
@@ -126,7 +134,7 @@ export default class ActionGroup extends React.Component<Props> {
       const defaultColor = tintColor
         ? tintColor
         : (textStyle || {}).color || BLACK_87PC_TRANSPARENT;
-      const color = i === destructiveButtonIndex ? destructiveColor : defaultColor;
+      const color = isIndexDestructive(i, destructiveButtonIndex) ? destructiveColor : defaultColor;
       const iconSource = icons != null ? icons[i] : null;
 
       optionViews.push(
@@ -169,7 +177,7 @@ const styles = StyleSheet.create({
     width: 24,
     height: 24,
     marginRight: 32,
-    justifyContent: "center",
+    justifyContent: 'center',
   },
   message: {
     marginTop: 12,

--- a/src/ActionSheet/index.ios.tsx
+++ b/src/ActionSheet/index.ios.tsx
@@ -34,6 +34,7 @@ export default class ActionSheet extends React.Component<Props> {
       anchor: dataOptions.anchor || undefined,
       userInterfaceStyle: dataOptions.userInterfaceStyle || undefined,
     };
+    // @ts-ignore: Even though ActionSheetIOS supports array of numbers for `destructiveIndex` the types are not yet updated. See https://github.com/facebook/react-native/pull/18254.
     ActionSheetIOS.showActionSheetWithOptions(iosOptions, onSelect);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,10 @@ import * as React from 'react';
 import { TextStyle, ViewStyle } from 'react-native';
 
 export interface ActionSheetProps {
-  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void | Promise<void>) => void;
+  showActionSheetWithOptions: (
+    options: ActionSheetOptions,
+    callback: (i: number) => void | Promise<void>
+  ) => void;
 }
 
 // for iOS
@@ -12,7 +15,7 @@ export interface ActionSheetIOSOptions {
   message?: string;
   tintColor?: string;
   cancelButtonIndex?: number;
-  destructiveButtonIndex?: number;
+  destructiveButtonIndex?: number | number[];
   anchor?: number;
   userInterfaceStyle?: 'light' | 'dark';
 }


### PR DESCRIPTION
This PR adds support for providing multiple indices to the `destructiveIndex` option.

This is [already supported in ActionSheetIOS](https://github.com/facebook/react-native/pull/18254). Please note that React Native's type definitions are not updated and it seems that `number[]` is not a valid type for `destructiveIndex`. You can easily test it and see that it actually works though.

I have also added support for multiple destructive indices on Android.

Resolves #25.