### PR TITLE
fix: change callback parameter type in showActionSheetWithOptions

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { ActionSheetOptions, ActionSheetProps } from './types';
 
 const context = React.createContext<ActionSheetProps>({
-  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => {},
+  showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number | undefined) => void) => {},
 });
 
 export function useActionSheet() {


### PR DESCRIPTION
Hi,

```js 
  ActionSheet.showActionSheetWithOptions(
      {
        options,
      },
      (i) => {
        setSelectedKind(kinds[i]);
      }
    );
```

I had a crash on this callback from **showActionSheetWithOptions**, when I finally did not select something on my android by clicking on the return button.
I thought that this callback would always return a number as mention here:
[https://github.com/expo/react-native-action-sheet/blob/master/src/context.ts#L5](url)
But it figures out that this crash happened because the callback parameter was equal to undefined.