### PR TITLE
docs: replace slack badge with discord badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # react-native-action-sheet
 [![npm](https://img.shields.io/npm/v/@expo/react-native-action-sheet.svg?style=flat-square)](https://www.npmjs.com/package/@expo/react-native-action-sheet)
 [![License: MIT](https://img.shields.io/github/license/nd-02110114/goofi-mobile.svg)](https://opensource.org/licenses/MIT)
-[![Slack](https://slack.expo.io/badge.svg)](https://slack.expo.io)
+[![Discord](https://img.shields.io/badge/discord-expo-green?style=flat-square&logo=discord)](https://discord.gg/4gtbPAdpaE)
 
 ActionSheet is a cross-platform React Native component that uses the native UIActionSheet on iOS and a JS implementation on Android. Almost a drop in replacement for [ActionSheetIOS](https://facebook.github.io/react-native/docs/actionsheetios.html) except it cannot be called statically.
 


### PR DESCRIPTION
Fixed the badge on README as the badge url for previous slack expo was broken, and the previous link (https://slack.expo.io/) redirects you to the discord invitation link.