### PR TITLE
chore: update Readme after lint stack bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,6 @@ $ yarn build
 // tsc
 $ yarn type-check
 
-// ESLint
+// ESLint + Prettier
 $ yarn lint
-
-// prettier
-$ yarn fmt
 ```


### PR DESCRIPTION
Refs #241 

Prettier format is now included in ESLint checks, so the `yarn fmt` command has been removed, but I have missed the guide in Readme file, sorry about that!