### PR TITLE
Stabilize the identity of the Provider value

### DIFF
--- a/src/ActionSheetProvider.tsx
+++ b/src/ActionSheetProvider.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import ActionSheet from './ActionSheet';
 import { Provider } from './context';
-import { ActionSheetOptions } from './types';
+import { ActionSheetOptions, ActionSheetProps } from './types';
 
 interface Props {
   children: React.ReactNode;
@@ -11,24 +11,27 @@ interface Props {
 
 export default class ActionSheetProvider extends React.Component<Props> {
   _actionSheetRef: React.RefObject<ActionSheet>;
+  _context: ActionSheetProps;
 
   constructor(props: Props) {
     super(props);
     this._actionSheetRef = React.createRef();
-  }
-
-  getContext = () => {
-    return {
+    this._context = {
       showActionSheetWithOptions: (options: ActionSheetOptions, callback: (i: number) => void) => {
-        this._actionSheetRef.current !== null &&
+        if (this._actionSheetRef.current != null) {
           this._actionSheetRef.current.showActionSheetWithOptions(options, callback);
+        }
       },
     };
-  };
+  }
+
+  getContext(): ActionSheetProps {
+    return this._context;
+  }
 
   render() {
     return (
-      <Provider value={this.getContext()}>
+      <Provider value={this._context}>
         <ActionSheet ref={this._actionSheetRef} useNativeDriver={this.props.useNativeDriver}>
           {React.Children.only(this.props.children)}
         </ActionSheet>


### PR DESCRIPTION
Currently, the Object that is passed into the `value` prop of the provider is generated on each render. This causes each subscriber of `useActionSheet` to re-render, unnecessarily.

This can also cause issues for any dependency arrays or PureComponents that are including `showActionSheetWithOptions`.

This PR will stabilize the identity of the `value`, so it won't change.

I'm not sure if the `getContext` function is necessary. I kept it in there in case it's being used somewhere that I can't see.