### PR TITLE
Added return type to connectActionSheet

### DIFF
--- a/src/connectActionSheet.tsx
+++ b/src/connectActionSheet.tsx
@@ -6,7 +6,7 @@ import { ActionSheetProps } from './types';
 
 export default function connectActionSheet<OwnProps = any>(
   WrappedComponent: React.ComponentType<OwnProps & ActionSheetProps>
-) {
+): React.FunctionComponent<OwnProps & ActionSheetProps> {
   const ConnectedActionSheet = (props: OwnProps) => {
     return (
       <Consumer>


### PR DESCRIPTION
This avoids importing hoist-non-react-statics in the built d.ts file causing errors when using typescript with esModuleInterop = false