### PR TITLE
Fix connectActionSheet to exclude ActionSheetProps from return type

### DIFF
--- a/src/connectActionSheet.tsx
+++ b/src/connectActionSheet.tsx
@@ -6,7 +6,7 @@ import { ActionSheetProps } from './types';
 
 export default function connectActionSheet<OwnProps = any>(
   WrappedComponent: React.ComponentType<OwnProps & ActionSheetProps>
-): React.FunctionComponent<OwnProps & ActionSheetProps> {
+): React.FunctionComponent<OwnProps> {
   const ConnectedActionSheet = (props: OwnProps) => {
     return (
       <Consumer>


### PR DESCRIPTION
The modification addresses an issue where react-navigation does not accept Screen components with props other than route and navigation, creating a problem since Screen components passing through connectActionSheet demand the showActionSheetWithOptions prop as dictated by ActionSheetProps.

The value of showActionSheetWithOptions defined in ActionSheetProps is already set within the connectActionSheet function, rendering it unnecessary in the return type. By removing ActionSheetProps from the function's output, we prevent the passing of redundant props and streamline the type definition of components involved.