### PR TITLE
fix: show touch feedback on iOS when using custom action sheet

### DIFF
--- a/src/ActionSheet/TouchableNativeFeedbackSafe.tsx
+++ b/src/ActionSheet/TouchableNativeFeedbackSafe.tsx
@@ -7,7 +7,7 @@ import {
   TouchableWithoutFeedbackProps,
 } from 'react-native';
 
-// This TouchableOpacity has the same staic method of TouchableNativeFeedback
+// This TouchableOpacity has the same static method of TouchableNativeFeedback
 class CustomTouchableOpacity extends React.Component {
   static SelectableBackground = () => ({});
   static SelectableBackgroundBorderless = () => ({});
@@ -19,8 +19,8 @@ class CustomTouchableOpacity extends React.Component {
 }
 
 const TouchableComponent = Platform.select({
-  web: CustomTouchableOpacity,
-  default: Platform.Version <= 20 ? CustomTouchableOpacity : TouchableNativeFeedback,
+  default: CustomTouchableOpacity,
+  android: Platform.Version <= 20 ? CustomTouchableOpacity : TouchableNativeFeedback,
 });
 
 type Props = TouchableWithoutFeedbackProps & {


### PR DESCRIPTION
Custom action sheet currently has no touch feedback on iOS. [`Platform.Version`](https://reactnative.dev/docs/platform#version) as a number and [`TouchableNativeFeedback`](https://reactnative.dev/docs/touchablenativefeedback) are Android only. Updated the `select` to reflect this.

Edit: Noticed there was actually feedback when the iOS version doesn't include a patch number (e.g. simulator with 17.4 vs my device with 17.5.1) and could be coerced into a number in the `Platform.Version <= 20` condition. But that should only be for android anyway